### PR TITLE
Refactor token parsing with handler mapping

### DIFF
--- a/esphome.mqtt.yaml
+++ b/esphome.mqtt.yaml
@@ -319,45 +319,52 @@ uart:
                     start_index = end_index;
                 }
 
-                // Log extracted tokens
+
+                const std::vector<std::function<void(const std::string&)>> handlers = {
+                    [](const std::string &v){ id(device_reply).publish_state(v.c_str()); },
+                    [](const std::string &v){ id(firmware_version).publish_state(v.c_str()); },
+                    [](const std::string &v){ id(operating_days).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(mpp_status).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(dc_disconnect).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(dc_relay).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(ac_relay).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(water_temperature).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(temperature_min).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(temperature_max).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(target_temperature_pv).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(target_temperature_grid).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(device_temperature).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(insulation_measurement).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(fault_code).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(input_voltage).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(input_current).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(power_now).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(energy_today).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(energy_total).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(grid_energy_today).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(grid_energy_total).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_22).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_23).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_24).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(runtime_today).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(grid_charge_start).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(lower_position).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(serial_number).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_29).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_30).publish_state(atof(v.c_str())); }
+                    // [](const std::string &v){ id(Token_31).publish_state(atof(v.c_str())); }
+                };
+
                 for (size_t i = 0; i < tokens.size(); i++) {
                     ESP_LOGD("main", "Token %d: %s", i, tokens[i].c_str());
-
-                    // Set the state of the corresponding sensor based on token index
-                    switch (i) {
-                        case 0: id(device_reply).publish_state(tokens[i].c_str()); break;
-                        case 1: id(firmware_version).publish_state(tokens[i].c_str()); break;
-                        case 2: id(operating_days).publish_state(atof(tokens[i].c_str())); break;
-                        case 3: id(mpp_status).publish_state(atof(tokens[i].c_str())); break;
-                        case 4: id(dc_disconnect).publish_state(atof(tokens[i].c_str())); break;
-                        case 5: id(dc_relay).publish_state(atof(tokens[i].c_str())); break;
-                        case 6: id(ac_relay).publish_state(atof(tokens[i].c_str())); break;
-                        case 7: id(water_temperature).publish_state(atof(tokens[i].c_str())); break;
-                        case 8: id(temperature_min).publish_state(atof(tokens[i].c_str())); break;
-                        case 9: id(temperature_max).publish_state(atof(tokens[i].c_str())); break;
-                        case 10: id(target_temperature_pv).publish_state(atof(tokens[i].c_str())); break;
-                        case 11: id(target_temperature_grid).publish_state(atof(tokens[i].c_str())); break;
-                        case 12: id(device_temperature).publish_state(atof(tokens[i].c_str())); break;
-                        case 13: id(insulation_measurement).publish_state(atof(tokens[i].c_str())); break;
-                        case 14: id(fault_code).publish_state(atof(tokens[i].c_str())); break;
-                        case 15: id(input_voltage).publish_state(atof(tokens[i].c_str())); break;
-                        case 16: id(input_current).publish_state(atof(tokens[i].c_str())); break;
-                        case 17: id(power_now).publish_state(atof(tokens[i].c_str())); break;
-                        case 18: id(energy_today).publish_state(atof(tokens[i].c_str())); break;
-                        case 19: id(energy_total).publish_state(atof(tokens[i].c_str())); break;
-                        case 20: id(grid_energy_today).publish_state(atof(tokens[i].c_str())); break;
-                        case 21: id(grid_energy_total).publish_state(atof(tokens[i].c_str())); break;
-                        case 22: id(unknown_22).publish_state(atof(tokens[i].c_str())); break;
-                        case 23: id(unknown_23).publish_state(atof(tokens[i].c_str())); break;
-                        case 24: id(unknown_24).publish_state(atof(tokens[i].c_str())); break;
-                        case 25: id(runtime_today).publish_state(atof(tokens[i].c_str())); break;
-                        case 26: id(grid_charge_start).publish_state(atof(tokens[i].c_str())); break;
-                        case 27: id(lower_position).publish_state(atof(tokens[i].c_str())); break;
-                        case 28: id(serial_number).publish_state(atof(tokens[i].c_str())); break;
-                        case 29: id(unknown_29).publish_state(atof(tokens[i].c_str())); break;
-                        case 30: id(unknown_30).publish_state(atof(tokens[i].c_str())); break;
-                        // case 31: id(Token_31).publish_state(atof(tokens[i].c_str())); break;
+                    if (i < handlers.size()) {
+                        handlers[i](tokens[i]);
+                    } else {
+                        ESP_LOGW("main", "Unhandled token %d with value %s", i, tokens[i].c_str());
                     }
+                }
+                if (tokens.size() != handlers.size()) {
+                    ESP_LOGW("main", "Token count mismatch: received %d tokens, expected %d", tokens.size(), handlers.size());
                 }
             } else {
                 // Handle the case where the content of str is "rs\r\n"  =>  ElwaDC is off due to drop of PV input voltage below threshold

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -319,45 +319,52 @@ uart:
                     start_index = end_index;
                 }
 
-                // Log extracted tokens
+
+                const std::vector<std::function<void(const std::string&)>> handlers = {
+                    [](const std::string &v){ id(device_reply).publish_state(v.c_str()); },
+                    [](const std::string &v){ id(firmware_version).publish_state(v.c_str()); },
+                    [](const std::string &v){ id(operating_days).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(mpp_status).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(dc_disconnect).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(dc_relay).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(ac_relay).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(water_temperature).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(temperature_min).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(temperature_max).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(target_temperature_pv).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(target_temperature_grid).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(device_temperature).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(insulation_measurement).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(fault_code).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(input_voltage).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(input_current).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(power_now).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(energy_today).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(energy_total).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(grid_energy_today).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(grid_energy_total).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_22).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_23).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_24).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(runtime_today).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(grid_charge_start).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(lower_position).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(serial_number).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_29).publish_state(atof(v.c_str())); },
+                    [](const std::string &v){ id(unknown_30).publish_state(atof(v.c_str())); }
+                    // [](const std::string &v){ id(Token_31).publish_state(atof(v.c_str())); }
+                };
+
                 for (size_t i = 0; i < tokens.size(); i++) {
                     ESP_LOGD("main", "Token %d: %s", i, tokens[i].c_str());
-
-                    // Set the state of the corresponding sensor based on token index
-                    switch (i) {
-                        case 0: id(device_reply).publish_state(tokens[i].c_str()); break;
-                        case 1: id(firmware_version).publish_state(tokens[i].c_str()); break;
-                        case 2: id(operating_days).publish_state(atof(tokens[i].c_str())); break;
-                        case 3: id(mpp_status).publish_state(atof(tokens[i].c_str())); break;
-                        case 4: id(dc_disconnect).publish_state(atof(tokens[i].c_str())); break;
-                        case 5: id(dc_relay).publish_state(atof(tokens[i].c_str())); break;
-                        case 6: id(ac_relay).publish_state(atof(tokens[i].c_str())); break;
-                        case 7: id(water_temperature).publish_state(atof(tokens[i].c_str())); break;
-                        case 8: id(temperature_min).publish_state(atof(tokens[i].c_str())); break;
-                        case 9: id(temperature_max).publish_state(atof(tokens[i].c_str())); break;
-                        case 10: id(target_temperature_pv).publish_state(atof(tokens[i].c_str())); break;
-                        case 11: id(target_temperature_grid).publish_state(atof(tokens[i].c_str())); break;
-                        case 12: id(device_temperature).publish_state(atof(tokens[i].c_str())); break;
-                        case 13: id(insulation_measurement).publish_state(atof(tokens[i].c_str())); break;
-                        case 14: id(fault_code).publish_state(atof(tokens[i].c_str())); break;
-                        case 15: id(input_voltage).publish_state(atof(tokens[i].c_str())); break;
-                        case 16: id(input_current).publish_state(atof(tokens[i].c_str())); break;
-                        case 17: id(power_now).publish_state(atof(tokens[i].c_str())); break;
-                        case 18: id(energy_today).publish_state(atof(tokens[i].c_str())); break;
-                        case 19: id(energy_total).publish_state(atof(tokens[i].c_str())); break;
-                        case 20: id(grid_energy_today).publish_state(atof(tokens[i].c_str())); break;
-                        case 21: id(grid_energy_total).publish_state(atof(tokens[i].c_str())); break;
-                        case 22: id(unknown_22).publish_state(atof(tokens[i].c_str())); break;
-                        case 23: id(unknown_23).publish_state(atof(tokens[i].c_str())); break;
-                        case 24: id(unknown_24).publish_state(atof(tokens[i].c_str())); break;
-                        case 25: id(runtime_today).publish_state(atof(tokens[i].c_str())); break;
-                        case 26: id(grid_charge_start).publish_state(atof(tokens[i].c_str())); break;
-                        case 27: id(lower_position).publish_state(atof(tokens[i].c_str())); break;
-                        case 28: id(serial_number).publish_state(atof(tokens[i].c_str())); break;
-                        case 29: id(unknown_29).publish_state(atof(tokens[i].c_str())); break;
-                        case 30: id(unknown_30).publish_state(atof(tokens[i].c_str())); break;
-                        // case 31: id(Token_31).publish_state(atof(tokens[i].c_str())); break;
+                    if (i < handlers.size()) {
+                        handlers[i](tokens[i]);
+                    } else {
+                        ESP_LOGW("main", "Unhandled token %d with value %s", i, tokens[i].c_str());
                     }
+                }
+                if (tokens.size() != handlers.size()) {
+                    ESP_LOGW("main", "Token count mismatch: received %d tokens, expected %d", tokens.size(), handlers.size());
                 }
             } else {
                 // Handle the case where the content of str is "rs\r\n"  =>  ElwaDC is off due to drop of PV input voltage below threshold


### PR DESCRIPTION
## Summary
- Replace long switch statements with vector of sensor-publishing handlers
- Iterate tokens via mapping and warn on unhandled entries

## Testing
- `esphome config esphome.yaml`
- `esphome config esphome.mqtt.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a9659e8634833380220a2bcb765c47