### PR TITLE
Fix YAML formatting and add yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+extends: default
+rules:
+  line-length: disable
+  comments-indentation: disable

--- a/esphome.mqtt.yaml
+++ b/esphome.mqtt.yaml
@@ -1,3 +1,4 @@
+---
 # Core Configuration
 # https://esphome.io/components/esphome.html
 esphome:
@@ -377,7 +378,7 @@ uart:
 
 # if you need to send a request periodically to get response from the uart device
 interval:
-  - interval: 20s #interval to request measurements
+  - interval: 20s  # interval to request measurements
     then:
       # request for getting all relevant token values 'rs'
       - uart.write: [0x72, 0x73, 0x0D, 0x0A]

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -1,3 +1,4 @@
+---
 # Core Configuration
 # https://esphome.io/components/esphome.html
 esphome:
@@ -377,7 +378,7 @@ uart:
 
 # if you need to send a request periodically to get response from the uart device
 interval:
-  - interval: 20s #interval to request measurements
+  - interval: 20s  # interval to request measurements
     then:
       # request for getting all relevant token values 'rs'
       - uart.write: [0x72, 0x73, 0x0D, 0x0A]

--- a/secrets.example.yaml
+++ b/secrets.example.yaml
@@ -1,3 +1,4 @@
+---
 # API
 api_encryption_key: 'your-base64-api-encryption-key'
 


### PR DESCRIPTION
## Summary
- add document start markers to YAML files
- normalize comment spacing and indentation
- configure yamllint to ignore long lines and comment indentation

## Testing
- `yamllint esphome.yaml esphome.mqtt.yaml secrets.example.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ab19803e248333908db1ade1dfb7a1